### PR TITLE
docs: add external-services recipe for proxying off-cluster services via Caddy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.claude

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A community-maintained collection of [Compose](https://compose-spec.io/) configu
 
 - [**NATS cluster**](nats/) - Deploys a [NATS](https://nats.io/) cluster, with the optional JetStream persistence layer.
 - [**WordPress with MariaDB**](wordpress-mariadb/) - Complete WordPress site with MariaDB database backend.
+- [**External services**](external-services/) - Expose services running outside of uncloud (bare-metal hosts, BMC controllers, smart home hubs) via the managed Caddy reverse proxy.
 
 ## Contributing
 

--- a/external-services/README.md
+++ b/external-services/README.md
@@ -1,0 +1,94 @@
+# External Services
+
+Expose services that run **outside** of your uncloud cluster — bare-metal installs, dedicated appliances, or devices with their own OS (such as a BMC controller or a smart home hub) — via the managed Caddy reverse proxy.
+
+## The problem
+
+Uncloud manages a Caddy instance that handles automatic TLS and DNS for everything it deploys. But some services can't or shouldn't run as containers: a HomeAssistant instance on a dedicated machine, a cluster board's BMC web interface, a NAS admin panel, and so on.
+
+These services are invisible to uncloud, so the usual `x-ports` mechanism doesn't apply. You still want them reachable at a clean `https://service.example.com` URL with a valid TLS certificate.
+
+## Solution
+
+The `uc caddy deploy` command accepts a `--caddyfile` flag pointing at a custom Caddyfile snippet. That snippet is prepended to the auto-generated Caddy config, so your external routes sit alongside all the routes uncloud manages — without touching those routes.
+
+```sh
+uc caddy deploy --caddyfile ./my-external-services.caddyfile
+```
+
+That's it. No containers to deploy or maintain.
+
+## Prerequisites
+
+- An uncloud cluster with Caddy deployed (`uc caddy deploy` without `--caddyfile` sets it up initially)
+- DNS configured to point your domain at the cluster
+- Network connectivity from the cluster nodes to the target service (same LAN, VPN, etc.)
+
+## Examples
+
+### HomeAssistant (plain HTTP upstream)
+
+HomeAssistant typically listens on HTTP on a dedicated host. See [`homeassistant.caddyfile`](homeassistant.caddyfile).
+
+```sh
+uc caddy deploy --caddyfile ./external-services/homeassistant.caddyfile
+```
+
+### BMC controller (HTTPS with self-signed certificate)
+
+BMC interfaces (e.g. TuringPi, iDRAC, iLO) serve HTTPS with self-signed certificates. Caddy needs `tls_insecure_skip_verify` to connect to the upstream while still presenting a valid certificate to the browser. See [`bmc.caddyfile`](bmc.caddyfile).
+
+```sh
+uc caddy deploy --caddyfile ./external-services/bmc.caddyfile
+```
+
+### Multiple services
+
+Combine multiple sites in one Caddyfile and deploy once:
+
+```
+homeassistant.example.com {
+  reverse_proxy 192.168.1.10:8123
+}
+
+bmc.example.com {
+  reverse_proxy https://192.168.1.75 {
+    transport http {
+      tls_insecure_skip_verify
+    }
+  }
+}
+```
+
+```sh
+uc caddy deploy --caddyfile ./external.caddyfile
+```
+
+## Inspecting the running config
+
+To see the full merged Caddyfile that Caddy is currently serving (your custom snippet + the auto-generated routes):
+
+```sh
+uc caddy config
+```
+
+## Alternative: stub service via x-caddy
+
+If you prefer to tie proxy configuration to the lifecycle of a `uc deploy` command rather than managing it separately, you can use the `x-caddy` compose extension on a stub service — a minimal container (e.g. `alpine` running `tail -f /dev/null`) that exists purely to inject a Caddyfile block:
+
+```yaml
+services:
+  homeassistant-proxy:
+    image: alpine:latest
+    command: ["tail", "-f", "/dev/null"]
+    x-caddy: |
+      homeassistant.example.com {
+        reverse_proxy 192.168.1.x:8123
+      }
+```
+
+```sh
+uc deploy -f compose.yaml
+```
+
+This approach is useful when the proxy config is coupled to a broader service deployment (e.g. deploying a companion service alongside the external target). For standalone external service routing, `uc caddy deploy --caddyfile` is simpler.

--- a/external-services/bmc.caddyfile
+++ b/external-services/bmc.caddyfile
@@ -1,0 +1,18 @@
+# Reverse proxy for a BMC controller (e.g. TuringPi, iDRAC, iLO) that serves
+# HTTPS with a self-signed certificate.
+#
+# tls_insecure_skip_verify allows Caddy to connect to the BMC's self-signed
+# upstream while still presenting a valid certificate to the browser.
+#
+# Replace:
+#   - bmc.example.com  with your domain
+#   - 192.168.1.x      with the IP of your BMC controller
+
+bmc.example.com {
+  reverse_proxy https://192.168.1.x {
+    transport http {
+      tls_insecure_skip_verify
+    }
+  }
+  log
+}

--- a/external-services/homeassistant.caddyfile
+++ b/external-services/homeassistant.caddyfile
@@ -1,0 +1,9 @@
+# Reverse proxy for HomeAssistant running on a dedicated host (plain HTTP upstream).
+#
+# Replace:
+#   - homeassistant.example.com  with your domain
+#   - 192.168.1.x                with the IP of your HomeAssistant host
+
+homeassistant.example.com {
+  reverse_proxy 192.168.1.x:8123
+}

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -3,6 +3,7 @@
 This is just a basic, single instance setup for now.
 
 TODOs:
+
 - Backup service
 - Primary and secondary instances with replication
 - Add `postgresql.conf` config file
@@ -22,7 +23,8 @@ Host access is enabled on `127.0.0.1:5432`.
 ### Connecting via ssh port-forwarding
 
 Where `$machine`, `$dbuser`, and `$dbname` from your setup earlier:
-```
+
+```sh
 ssh -fN -L 5555:localhost:5432 $machine
 psql -h localhost -p 5555 -U $dbuser $dbname
 ```


### PR DESCRIPTION
## Summary

Adds a new `external-services` recipe documenting how to expose services that run outside of an uncloud cluster (bare-metal hosts, BMC controllers, smart home hubs) through the cluster's managed Caddy reverse proxy.

The primary approach uses `uc caddy deploy --caddyfile`, which prepends a custom Caddyfile snippet to the auto-generated config — no containers to deploy or maintain. The stub-service `x-caddy` approach is also documented as an alternative for cases where proxy config needs to be lifecycle-coupled to a `uc deploy`.

Includes two example Caddyfiles:
- `homeassistant.caddyfile` — plain HTTP upstream
- `bmc.caddyfile` — HTTPS upstream with `tls_insecure_skip_verify` for self-signed certificates (BMC controllers, iDRAC, iLO, etc.)